### PR TITLE
Removed "Caches" from exclusions

### DIFF
--- a/Redirections/Redirections.csv
+++ b/Redirections/Redirections.csv
@@ -28,7 +28,6 @@ Exclude,0,AppData\Local\Microsoft\UEV,Microsoft UEV,
 Exclude,0,AppData\Local\Microsoft\Windows\Mail,Microsoft Mail,
 Exclude,0,AppData\Local\Microsoft\Windows\WebCache.old,Microsoft Windows,
 Exclude,0,AppData\Local\Microsoft\Windows\AppCache,Microsoft Windows,
-Exclude,0,AppData\Local\Microsoft\Windows\Caches,Microsoft Windows,
 Exclude,0,AppData\Local\Microsoft\Windows\Explorer,Windows Explorer cache,May impact Explorer performance for thumbnails
 Exclude,0,AppData\Local\Microsoft\Windows\GameExplorer,Windows Game Explorer cache,
 Exclude,0,AppData\Local\Microsoft\Windows\DNTException,Microsoft Windows,


### PR DESCRIPTION
This one seems to break the Server 2019 Start Menu tiles.  

<Exclude Copy="0">AppData\Local\Microsoft\Windows\Caches</Exclude>

See picture:  https://imgur.com/a/b8SpM7r

I removed this from the redirections.csv