### PR TITLE
Remove AppData\Local\Microsoft\Windows\Caches

### DIFF
--- a/Redirections/AdditionalRedirectionsList.csv
+++ b/Redirections/AdditionalRedirectionsList.csv
@@ -28,7 +28,6 @@ Exclude,0,AppData\Local\Microsoft\UEV,Microsoft UEV,
 Exclude,0,AppData\Local\Microsoft\Windows\Mail,Microsoft Mail,
 Exclude,0,AppData\Local\Microsoft\Windows\WebCache.old,Microsoft Windows,
 Exclude,0,AppData\Local\Microsoft\Windows\AppCache,Microsoft Windows,
-Exclude,0,AppData\Local\Microsoft\Windows\Caches,Microsoft Windows,
 Exclude,0,AppData\Local\Microsoft\Windows\Explorer,Windows Explorer cache,May impact Explorer performance for thumbnails
 Exclude,0,AppData\Local\Microsoft\Windows\GameExplorer,Windows Game Explorer cache,
 Exclude,0,AppData\Local\Microsoft\Windows\DNTException,Microsoft Windows,


### PR DESCRIPTION
Removed AppData\Local\Microsoft\Windows\Caches from being excluded as this seems to break start menus on Windows 10 1809 with latest release of FSLogix

Thanks to @eckerle_m for https://twitter.com/eckerle_m/status/1148680216199540737